### PR TITLE
EIP1-1144 Add EMS CIDR update queue env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Requests are assumed pre-authenticated which carry a header defined by property 
 The following environment variables must be set in order to run the application: 
 - `REQUEST_HEADER_CLIENT_CERT_SERIAL` is the name of header required in request
 - `API_IER_URL` is the base URL of the external IER API service
+- `SQS_EMS_CIDR_UPDATE_QUEUE_NAME` is the name of the queue for EMS CIDR update notifications from IER 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,6 @@ dluhc:
 api:
   ier:
     url: ${API_IER_URL}
+
+sqs:
+  ems-cidr-update-queue-name: ${SQS_EMS_CIDR_UPDATE_QUEUE_NAME}


### PR DESCRIPTION
Adds a placeholder env var for the queue that IER are using for their connectivity testing (ahead of its use within this service).