### PR TITLE
NO-JIRA - bump dependency versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 import org.owasp.dependencycheck.reporting.ReportGenerator.Format.HTML
 
 plugins {
-    id("org.springframework.boot") version "2.7.2"
-    id("io.spring.dependency-management") version "1.0.12.RELEASE"
+    id("org.springframework.boot") version "2.7.3"
+    id("io.spring.dependency-management") version "1.0.13.RELEASE"
     kotlin("jvm") version "1.7.0"
     kotlin("plugin.spring") version "1.7.0"
     kotlin("plugin.jpa") version "1.7.0"
@@ -13,7 +13,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
     id("org.jlleitschuh.gradle.ktlint-idea") version "10.3.0"
     id("org.openapi.generator") version "6.0.1"
-    id("org.owasp.dependencycheck") version "7.1.1"
+    id("org.owasp.dependencycheck") version "7.1.2"
 }
 
 group = "uk.gov.dluhc"
@@ -42,7 +42,7 @@ dependencies {
 
     // api
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springdoc:springdoc-openapi-ui:1.6.9")
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.11")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // webclient
@@ -130,5 +130,6 @@ dependencyCheck {
     failOnError = true
     failBuildOnCVSS = 0.toFloat()
     analyzers.assemblyEnabled = false
+    analyzers.centralEnabled = true
     format = HTML
 }


### PR DESCRIPTION
This PR bumps the version of a few dependencies. It does not reduce the number of reported vulnerabilities, but its still the right thing to do

```
nathan@MacBook-Pro-2 ~/projects/valtech/dluhc-eip/eip-ero-register-checker-api (main)
$ ./gradlew clean dependencyAnalyze
Starting a Gradle Daemon, 3 stopped Daemons could not be reused, use --status for details

> Task :dependencyCheckAnalyze
Verifying dependencies for project eip-ero-register-checker-api
Checking for updates and analyzing dependencies for vulnerabilities
Generating report for project eip-ero-register-checker-api
Found 2 vulnerabilities in project eip-ero-register-checker-api


One or more dependencies were identified with known vulnerabilities in eip-ero-register-checker-api:

spring-security-crypto-5.7.3.jar (pkg:maven/org.springframework.security/spring-security-crypto@5.7.3, cpe:2.3:a:pivotal_software:spring_security:5.7.3:*:*:*:*:*:*:*, cpe:2.3:a:vmware:spring_security:5.7.3:*:*:*:*:*:*:*) : CVE-2020-5408
spring-web-5.3.22.jar (pkg:maven/org.springframework/spring-web@5.3.22, cpe:2.3:a:pivotal_software:spring_framework:5.3.22:*:*:*:*:*:*:*, cpe:2.3:a:springsource:spring_framework:5.3.22:*:*:*:*:*:*:*, cpe:2.3:a:vmware:spring_framework:5.3.22:*:*:*:*:*:*:*) : CVE-2016-1000027


See the dependency-check report for more details.



> Task :dependencyCheckAnalyze FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':dependencyCheckAnalyze'.
> 
  
  Dependency-Analyze Failure:
  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than '0.0': CVE-2020-5408, CVE-2016-1000027
  See the dependency-check report for more details.
  


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 22s
2 actionable tasks: 2 executed
```