### PR TITLE
EIP1-1701: Fix OWASP vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 group = "uk.gov.dluhc"
 version = "latest"
 java.sourceCompatibility = JavaVersion.VERSION_17
+ext["snakeyaml.version"] = "1.31"
 
 repositories {
     mavenCentral()
@@ -44,7 +45,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springdoc:springdoc-openapi-ui:1.6.11")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.yaml:snakeyaml:1.31")
 
     // webclient
     implementation("org.springframework:spring-webflux")

--- a/owasp.suppressions.xml
+++ b/owasp.suppressions.xml
@@ -1,16 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-      file name: spring-security-crypto-5.7.3.jar
-      ]]></notes>
+    <suppress until="2023-09-07Z">
+        <notes>
+            <![CDATA[ file name: spring-security-crypto-5.7.3.jar]]>
+            The method with the vulnerability is deprecated now, but not removed yet.
+            It will be removed as part of Spring 6.
+            The warning is suppressed until then.
+            https://github.com/spring-projects/spring-security/issues/8980
+        </notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-web-5.3.22.jar
-   ]]></notes>
+    <suppress until="2023-09-07Z">
+        <notes>
+            <![CDATA[file name: spring-web-5.3.22.jar]]>
+            The vulnerability is on Spring HTTP Invoker, and it is deprecated by Spring, but not removed yet.
+            It is not used in our code base and seen as a JVM deserialization issue rather than a Spring one by the Spring team.
+            It doesn't look like it will be address any time soon, and since we don't use it, it is suppressed as well.
+            https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#remoting-httpinvoker
+            https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-744519525
+        </notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>


### PR DESCRIPTION
This PR is to address the 3 OWASP warnings by updating the `snakeyaml` dependency to version `1.31` and suppressing the 2 remaining warnings. 

The suppression reasons as stated by @NathanRussellValtech are:

> They are listed as vulnerabilities in spring boot, but the SB team is basically saying they won't be fixing them.
> Because there is no fix, and no risk, you can suppress the warnings.

<img width="887" alt="image" src="https://user-images.githubusercontent.com/39367710/188689365-01101ac3-39f4-4979-89fa-d4f8c9965e8c.png">
