### PR TITLE
Feature/eip1 1820 find pending multiple gsscodes

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/CustomRegisterCheckRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/CustomRegisterCheckRepository.kt
@@ -4,5 +4,5 @@ import uk.gov.dluhc.registercheckerapi.database.entity.RegisterCheck
 
 interface CustomRegisterCheckRepository {
 
-    fun findPendingEntriesByGssCode(gssCode: String, limit: Int = 100): List<RegisterCheck>
+    fun findPendingEntriesByGssCodes(gssCodes: List<String>, limit: Int = 100): List<RegisterCheck>
 }

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/RegisterCheckRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/RegisterCheckRepository.kt
@@ -1,12 +1,16 @@
 package uk.gov.dluhc.registercheckerapi.database.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.stereotype.Repository
 import uk.gov.dluhc.registercheckerapi.database.entity.RegisterCheck
 import java.util.UUID
 
 @Repository
-interface RegisterCheckRepository : JpaRepository<RegisterCheck, UUID>, CustomRegisterCheckRepository {
+interface RegisterCheckRepository :
+    JpaRepository<RegisterCheck, UUID>,
+    CustomRegisterCheckRepository,
+    JpaSpecificationExecutor<RegisterCheck> {
 
     fun findByCorrelationId(correlationId: UUID): RegisterCheck?
 }

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/RegisterCheckRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/RegisterCheckRepositoryImpl.kt
@@ -8,14 +8,14 @@ import javax.persistence.PersistenceContext
 @Repository
 class RegisterCheckRepositoryImpl(@PersistenceContext val entityManager: EntityManager) : CustomRegisterCheckRepository {
 
-    override fun findPendingEntriesByGssCode(gssCode: String, limit: Int): List<RegisterCheck> {
+    override fun findPendingEntriesByGssCodes(gssCodes: List<String>, limit: Int): List<RegisterCheck> {
         val query = """SELECT rc FROM RegisterCheck rc 
                JOIN FETCH rc.personalDetail pd 
                JOIN FETCH pd.address a 
-               WHERE rc.status = 'PENDING' AND rc.gssCode = :gssCode 
+               WHERE rc.status = 'PENDING' AND rc.gssCode IN (:gssCodes) 
                ORDER BY rc.dateCreated"""
         return entityManager.createQuery(query, RegisterCheck::class.java)
-            .setParameter("gssCode", gssCode)
+            .setParameter("gssCodes", gssCodes)
             .setMaxResults(limit)
             .resultList
     }

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/IntegrationTest.kt
@@ -11,7 +11,6 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.sqs.SqsClient
 import uk.gov.dluhc.registercheckerapi.database.repository.RegisterCheckRepository
 import uk.gov.dluhc.registercheckerapi.testsupport.WiremockService
-import javax.persistence.EntityManagerFactory
 
 /**
  * Base class used to bring up the entire Spring ApplicationContext
@@ -20,9 +19,6 @@ import javax.persistence.EntityManagerFactory
 @ActiveProfiles("test")
 @AutoConfigureWebTestClient(timeout = "PT5M")
 internal abstract class IntegrationTest {
-
-    @Autowired
-    protected lateinit var entityManagerFactory: EntityManagerFactory
 
     @Autowired
     protected lateinit var webTestClient: WebTestClient

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/RegisterCheckRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/database/repository/RegisterCheckRepositoryTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.registercheckerapi.database.repository
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.dluhc.registercheckerapi.config.IntegrationTest
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.entity.buildRegisterCheck
@@ -8,87 +9,96 @@ import java.util.UUID
 
 internal class RegisterCheckRepositoryTest : IntegrationTest() {
 
-    @Test
-    fun `should retrieve pending register checks by gss code`() {
-        // Given
-        val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
-        val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
-        registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2))
+    @Nested
+    inner class FindByGssCodes {
+        @Test
+        fun `should retrieve pending register checks by multiple gss codes`() {
+            // Given
+            val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
+            val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
+            val registerCheck3 = buildRegisterCheck(gssCode = "E09000022")
+            registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2, registerCheck3))
 
-        // When
-        val actual = registerCheckRepository.findPendingEntriesByGssCode("E09000020")
+            // When
+            val actual = registerCheckRepository.findPendingEntriesByGssCodes(listOf("E09000020", "E09000022"))
 
-        // Then
-        assertThat(actual).isNotNull
-        assertThat(actual).containsExactly(registerCheck1)
-        assertThat(actual[0].id).isNotNull
-        assertThat(actual[0].dateCreated).isNotNull
-        assertThat(actual[0].updatedAt).isNotNull
-        assertThat(actual[0].version).isNotNull
+            // Then
+            assertThat(actual).isNotNull
+            assertThat(actual).containsExactlyInAnyOrder(registerCheck1, registerCheck3)
+            actual.forEach {
+                assertThat(it.id).isNotNull
+                assertThat(it.dateCreated).isNotNull
+                assertThat(it.updatedAt).isNotNull
+                assertThat(it.version).isNotNull
+            }
+        }
+
+        @Test
+        fun `should retrieve limited number of pending register checks by gss code`() {
+            // Given
+            val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
+            registerCheckRepository.save(registerCheck1)
+            // sleep to guarantee order by date_created asc
+            Thread.sleep(1000)
+            val registerCheck2 = buildRegisterCheck(gssCode = "E09000020")
+            registerCheckRepository.save(registerCheck2)
+            Thread.sleep(1000)
+            val registerCheck3 = buildRegisterCheck(gssCode = "E09000020")
+            registerCheckRepository.save(registerCheck3)
+
+            // When
+            val actual = registerCheckRepository.findPendingEntriesByGssCodes(listOf("E09000020"), 2)
+
+            // Then
+            assertThat(actual).isNotNull
+            assertThat(actual).containsExactly(registerCheck1, registerCheck2)
+        }
+
+        @Test
+        fun `should not retrieve pending register checks by unknown gss code`() {
+            // Given
+            val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
+            val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
+            registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2))
+
+            // When
+            val actual = registerCheckRepository.findPendingEntriesByGssCodes(listOf("UNKNOWN"))
+
+            // Then
+            assertThat(actual).isNotNull
+            assertThat(actual).isEmpty()
+        }
     }
 
-    @Test
-    fun `should retrieve limited number of pending register checks by gss code`() {
-        // Given
-        val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
-        registerCheckRepository.save(registerCheck1)
-        // sleep to guarantee order by date_created asc
-        Thread.sleep(1000)
-        val registerCheck2 = buildRegisterCheck(gssCode = "E09000020")
-        registerCheckRepository.save(registerCheck2)
-        Thread.sleep(1000)
-        val registerCheck3 = buildRegisterCheck(gssCode = "E09000020")
-        registerCheckRepository.save(registerCheck3)
+    @Nested
+    inner class FindByCorrelationId {
+        @Test
+        fun `should get register check by correlation id`() {
+            // Given
+            val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
+            val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
+            registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2))
 
-        // When
-        val actual = registerCheckRepository.findPendingEntriesByGssCode("E09000020", 2)
+            // When
+            val actual = registerCheckRepository.findByCorrelationId(registerCheck1.correlationId)
 
-        // Then
-        assertThat(actual).isNotNull
-        assertThat(actual).containsExactly(registerCheck1, registerCheck2)
-    }
+            // Then
+            assertThat(actual).isNotNull
+            assertThat(actual).isEqualTo(registerCheck1)
+        }
 
-    @Test
-    fun `should not retrieve pending register checks by unknown gss code`() {
-        // Given
-        val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
-        val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
-        registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2))
+        @Test
+        fun `should not get register check by unknown correlation id`() {
+            // Given
+            val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
+            val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
+            registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2))
 
-        // When
-        val actual = registerCheckRepository.findPendingEntriesByGssCode("UNKNOWN")
+            // When
+            val actual = registerCheckRepository.findByCorrelationId(UUID.randomUUID())
 
-        // Then
-        assertThat(actual).isNotNull
-        assertThat(actual).isEmpty()
-    }
-
-    @Test
-    fun `should get register check by correlation id`() {
-        // Given
-        val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
-        val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
-        registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2))
-
-        // When
-        val actual = registerCheckRepository.findByCorrelationId(registerCheck1.correlationId)
-
-        // Then
-        assertThat(actual).isNotNull
-        assertThat(actual).isEqualTo(registerCheck1)
-    }
-
-    @Test
-    fun `should not get register check by unknown correlation id`() {
-        // Given
-        val registerCheck1 = buildRegisterCheck(gssCode = "E09000020")
-        val registerCheck2 = buildRegisterCheck(gssCode = "E09000021")
-        registerCheckRepository.saveAll(listOf(registerCheck1, registerCheck2))
-
-        // When
-        val actual = registerCheckRepository.findByCorrelationId(UUID.randomUUID())
-
-        // Then
-        assertThat(actual).isNull()
+            // Then
+            assertThat(actual).isNull()
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
@@ -18,7 +18,9 @@ import uk.gov.dluhc.registercheckerapi.testsupport.testdata.models.buildInitiate
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import javax.persistence.criteria.CriteriaBuilder
 import javax.persistence.criteria.CriteriaQuery
+import javax.persistence.criteria.Root
 
 private val logger = KotlinLogging.logger {}
 
@@ -84,20 +86,8 @@ internal class InitiateRegisterCheckMessageListenerIntegrationTest : Integration
         }
     }
 
-    private fun getActualRegisterCheckJpaEntity(message: InitiateRegisterCheckMessage): List<RegisterCheck> {
-        val entityManager = entityManagerFactory.createEntityManager()
-        try {
-            val cb = entityManager.criteriaBuilder
-            val queryDef: CriteriaQuery<RegisterCheck> = cb.createQuery(RegisterCheck::class.java)
-            val rc = queryDef.from(RegisterCheck::class.java)
-            queryDef.select(
-                rc
-            ).where(
-                cb.equal(rc.get<UUID>("sourceCorrelationId"), message.sourceCorrelationId)
-            )
-            return entityManager.createQuery(queryDef).resultList
-        } finally {
-            entityManager.close()
+    private fun getActualRegisterCheckJpaEntity(message: InitiateRegisterCheckMessage): List<RegisterCheck> =
+        registerCheckRepository.findAll { root: Root<RegisterCheck>, _: CriteriaQuery<*>, cb: CriteriaBuilder ->
+            cb.equal(root.get<UUID>("sourceCorrelationId"), message.sourceCorrelationId)
         }
-    }
 }


### PR DESCRIPTION
This PR modifies findPendingEntriesByGssCodes to accept a list of gssCodes.
Also refactors getActualRegisterCheckJpaEntity to use a JPA specification.