### PR TITLE
EIP1-403: EIP1-2004: Query param [requestId] type changed to UUID

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapper.kt
@@ -10,6 +10,7 @@ import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckResultDto
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus
 import uk.gov.dluhc.registercheckerapi.models.RegisterCheckMatch
 import uk.gov.dluhc.registercheckerapi.models.RegisterCheckResultRequest
+import java.util.UUID
 
 /**
  * Maps [RegisterCheckResultRequest] to [RegisterCheckResultDto].
@@ -17,13 +18,13 @@ import uk.gov.dluhc.registercheckerapi.models.RegisterCheckResultRequest
 @Mapper(uses = [InstantMapper::class])
 abstract class RegisterCheckResultMapper {
 
-    @Mapping(target = "requestId", expression = "java(UUID.fromString(queryParamRequestId))")
+    @Mapping(target = "requestId", source = "queryParamRequestId")
     @Mapping(target = "correlationId", source = "apiRequest.requestid")
     @Mapping(target = "matchResultSentAt", source = "apiRequest.createdAt")
     @Mapping(target = "matchCount", source = "apiRequest.registerCheckMatchCount")
     @Mapping(target = "registerCheckStatus", source = "apiRequest.registerCheckMatchCount", qualifiedByName = ["evaluateRegisterCheckStatus"])
     @Mapping(target = "registerCheckMatchDto", source = "apiRequest.registerCheckMatches")
-    abstract fun fromRegisterCheckResultRequestApiToDto(queryParamRequestId: String, apiRequest: RegisterCheckResultRequest): RegisterCheckResultDto
+    abstract fun fromRegisterCheckResultRequestApiToDto(queryParamRequestId: UUID, apiRequest: RegisterCheckResultRequest): RegisterCheckResultDto
 
     @Mapping(target = "personalDetail", source = ".")
     protected abstract fun fromRegisterCheckMatchApiToDto(registerCheckMatchApi: RegisterCheckMatch): RegisterCheckMatchDto

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/RegisterCheckerController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/RegisterCheckerController.kt
@@ -17,6 +17,7 @@ import uk.gov.dluhc.registercheckerapi.mapper.RegisterCheckResultMapper
 import uk.gov.dluhc.registercheckerapi.models.PendingRegisterChecksResponse
 import uk.gov.dluhc.registercheckerapi.models.RegisterCheckResultRequest
 import uk.gov.dluhc.registercheckerapi.service.RegisterCheckService
+import java.util.UUID
 import javax.validation.Valid
 
 private val logger = KotlinLogging.logger {}
@@ -58,7 +59,7 @@ class RegisterCheckerController(
     @ResponseStatus(CREATED)
     fun updatePendingRegisterCheck(
         authentication: Authentication,
-        @PathVariable requestId: String,
+        @PathVariable requestId: UUID,
         @Valid @RequestBody request: RegisterCheckResultRequest
     ) {
         logger.info("Updating pending register checks for EMS ERO certificateSerial=[${authentication.credentials}] with requestId=[$requestId]")

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapperTest.kt
@@ -60,7 +60,7 @@ internal class RegisterCheckResultMapperTest {
             expectedRegisterCheckStatus: RegisterCheckStatus
         ) {
             // Given
-            val queryParamRequestId = UUID.randomUUID().toString()
+            val queryParamRequestId = UUID.randomUUID()
             val createdAt = OffsetDateTime.now()
             val applicationCreatedAt = OffsetDateTime.now().minusDays(5)
             val apiRequest = buildRegisterCheckResultRequest(
@@ -75,7 +75,7 @@ internal class RegisterCheckResultMapperTest {
             given(instantMapper.toInstant(eq(applicationCreatedAt))).willReturn(expectedApplicationCreatedAt)
 
             val expected = RegisterCheckResultDto(
-                requestId = UUID.fromString(queryParamRequestId),
+                requestId = queryParamRequestId,
                 correlationId = apiRequest.requestid,
                 gssCode = apiRequest.gssCode,
                 matchResultSentAt = expectedMatchSentAt,
@@ -99,7 +99,7 @@ internal class RegisterCheckResultMapperTest {
         @Test
         fun `should map api to dto when optional fields are null`() {
             // Given
-            val queryParamRequestId = UUID.randomUUID().toString()
+            val queryParamRequestId = UUID.randomUUID()
             val createdAt = OffsetDateTime.now()
             val apiRequest = buildRegisterCheckResultRequest(
                 createdAt = createdAt,
@@ -112,7 +112,7 @@ internal class RegisterCheckResultMapperTest {
             given(instantMapper.toInstant(eq(createdAt))).willReturn(createdAt.toInstant())
 
             val expected = RegisterCheckResultDto(
-                requestId = UUID.fromString(queryParamRequestId),
+                requestId = queryParamRequestId,
                 correlationId = apiRequest.requestid,
                 gssCode = apiRequest.gssCode,
                 matchResultSentAt = expectedMatchSentAt,

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
@@ -46,7 +46,7 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
 
         // When
         val response = webTestClient.post()
-            .uri(buildUri(requestIdInQueryParam.toString()))
+            .uri(buildUri(requestIdInQueryParam))
             .header(REQUEST_HEADER_NAME, CERT_SERIAL_NUMBER_VALUE)
             .contentType(APPLICATION_JSON)
             .body(
@@ -79,7 +79,7 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
 
         // When
         val response = webTestClient.post()
-            .uri(buildUri(requestId.toString()))
+            .uri(buildUri(requestId))
             .header(REQUEST_HEADER_NAME, CERT_SERIAL_NUMBER_VALUE)
             .contentType(APPLICATION_JSON)
             .body(
@@ -116,7 +116,7 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
 
         // When
         val response = webTestClient.post()
-            .uri(buildUri(requestId.toString()))
+            .uri(buildUri(requestId))
             .header(REQUEST_HEADER_NAME, CERT_SERIAL_NUMBER_VALUE)
             .contentType(APPLICATION_JSON)
             .body(
@@ -154,7 +154,7 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
 
         // When
         val response = webTestClient.post()
-            .uri(buildUri(requestId.toString()))
+            .uri(buildUri(requestId))
             .header(REQUEST_HEADER_NAME, CERT_SERIAL_NUMBER_VALUE)
             .contentType(APPLICATION_JSON)
             .body(
@@ -187,7 +187,7 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
 
         // When
         val response = webTestClient.post()
-            .uri(buildUri(requestId.toString()))
+            .uri(buildUri(requestId))
             .header(REQUEST_HEADER_NAME, CERT_SERIAL_NUMBER_VALUE)
             .contentType(APPLICATION_JSON)
             .body(
@@ -220,7 +220,7 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
 
         // When
         val response = webTestClient.post()
-            .uri(buildUri(requestId.toString()))
+            .uri(buildUri(requestId))
             .header(REQUEST_HEADER_NAME, CERT_SERIAL_NUMBER_VALUE)
             .contentType(APPLICATION_JSON)
             .body(
@@ -347,6 +347,6 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
             .hasValidationError("Error on field 'registerCheckMatches[0].email': rejected value [not an email address], must be a well-formed email address")
     }
 
-    private fun buildUri(requestId: String = UUID.randomUUID().toString()) =
+    private fun buildUri(requestId: UUID = UUID.randomUUID()) =
         "/registerchecks/$requestId"
 }


### PR DESCRIPTION
`requestid` as per swagger spec is of type UUID, this PR changes it to be `UUID` instead of `String`

<img width="741" alt="image" src="https://user-images.githubusercontent.com/73763010/193638547-261d0e79-604e-47ed-a8f2-2c640ad08208.png">
