### PR TITLE
NO_JIRA: Enable/disable log statement when header is not present

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/RegisterCheckerHeaderAuthenticationFilter.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/RegisterCheckerHeaderAuthenticationFilter.kt
@@ -33,7 +33,7 @@ class RegisterCheckerHeaderAuthenticationFilter(requestHeaderName: String) : Req
         val requestHeaderValue = super.getPreAuthenticatedPrincipal(servletRequest as HttpServletRequest?) as String?
 
         if (requestHeaderValue.isNullOrBlank()) {
-            logger.info("[$clientCertSerialHeaderName] header is not present in request header")
+            logger.debug("[$clientCertSerialHeaderName] header is not present in request header")
         } else {
             val authToken =
                 PreAuthenticatedAuthenticationToken(clientCertSerialHeaderName, requestHeaderValue, AUTHORITIES)


### PR DESCRIPTION
@sentioservices noticed that there were lots of log statements in the RCA logs.

I think these are due to K8s  `health-check` calling RCA endpoints without any header (which is expected).
Few options are:

1. Change it to debug (and once log config is there to only show debug, then these log statements will be shown) or
2. Remove this log statement altogether, which means when `AWS lambda` calls `RCA Get/Post` without header, then this log won't be shown
3. Option 3 - Is it worth it to add more logic here (I think no) to say don't log if it's K8s calling it.

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/73763010/194861539-3d74e588-947d-4e30-bcc1-079ebc5ddef7.png">

