### PR TITLE
EIP1-403: EIP1-2103: Renames register check match table's [correlation_id] column to [register_check_id]

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/entity/RegisterCheck.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/entity/RegisterCheck.kt
@@ -78,7 +78,7 @@ class RegisterCheck(
     var matchResultSentAt: Instant? = null,
 
     @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-    @JoinColumn(name = "correlation_id", nullable = false)
+    @JoinColumn(name = "register_check_id", referencedColumnName = "id", nullable = false)
     var registerCheckMatches: MutableList<RegisterCheckMatch> = mutableListOf(),
 
     @NotNull

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckService.kt
@@ -68,7 +68,10 @@ class RegisterCheckService(
             }
         }
         with(registerCheckResultMessageMapper.fromRegisterCheckEntityToRegisterCheckResultMessage(registerCheck)) {
-            logger.info { "Publishing ConfirmRegisterCheckResultMessage with sourceType:[$sourceType], sourceReferenceApplicationId:[$sourceReference], sourceCorrelationId:[$sourceCorrelationId]" }
+            logger.info {
+                "Publishing ConfirmRegisterCheckResultMessage with sourceType:[$sourceType], sourceReferenceApplicationId:[$sourceReference], " +
+                    "sourceCorrelationId:[$sourceCorrelationId] for correlationId:[${registerCheck.correlationId}]"
+            }
             confirmRegisterCheckResultMessageQueue.submit(this)
         }
     }
@@ -81,6 +84,11 @@ class RegisterCheckService(
                 1 -> registerCheck.recordExactMatch(matchResultSentAt, matches.first())
                 in 2..10 -> registerCheck.recordMultipleMatches(matchResultSentAt, matchCount, matches)
                 else -> registerCheck.recordTooManyMatches(matchResultSentAt, matchCount, matches)
+            }.also {
+                logger.info {
+                    "Updated register check status to [${registerCheck.status}], matchCount to [${registerCheck.matchCount}], " +
+                        "matchResultSentAt to [${registerCheck.matchResultSentAt}] for correlationId:[${registerCheck.correlationId}]"
+                }
             }
         }
     }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -13,5 +13,6 @@
     <include relativeToChangelogFile="true" file="ddl/0005_alter_address.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0006_register_check_match.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0007_register_check_result_data.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0008_alter_register_check_match.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0008_alter_register_check_match.xml
+++ b/src/main/resources/db/changelog/ddl/0008_alter_register_check_match.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+
+    <changeSet author="vishal.gupta@valtech.com" id="0008_EIP1-493_alter_register_check_match - Rename correlation_id to register_check_id column" context="ddl">
+        <renameColumn tableName="register_check_match"
+                      oldColumnName="correlation_id"
+                      newColumnName="register_check_id"
+                      columnDataType="uuid"/>
+        <rollback>
+            <renameColumn tableName="register_check_match"
+                          oldColumnName="register_check_id"
+                          newColumnName="correlation_id"
+                          columnDataType="uuid"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="vishal.gupta@valtech.com" id="0008_EIP1-493_alter_register_check_match - Drop index" context="ddl" >
+        <dropIndex tableName="register_check_match"
+                   indexName="register_check_match_correlation_id_idx"/>
+        <rollback>
+            <createIndex tableName="register_check_match"
+                         indexName="register_check_match_correlation_id_idx">
+                <column name="correlation_id"/>
+            </createIndex>
+        </rollback>
+    </changeSet>
+
+   <changeSet author="vishal.gupta@valtech.com" id="0008_EIP1-493_alter_register_check_match - Create index" context="ddl" >
+        <createIndex tableName="register_check_match"
+                     indexName="register_check_match_register_check_id_idx">
+            <column name="register_check_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="register_check_match"
+                       indexName="register_check_match_register_check_id_idx"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
  - Also updates integration test assertions
  - Also enhances log messages

<img width="517" alt="image" src="https://user-images.githubusercontent.com/73763010/195075973-b74388c2-ea32-41b9-bc92-f10aad7527fe.png">

<img width="657" alt="image" src="https://user-images.githubusercontent.com/73763010/195076018-5192bc02-a8fc-44ba-99c6-6e1293dd9a60.png">

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/73763010/195076239-217b8b39-f904-47ef-89cf-602dc283d721.png">

<img width="1469" alt="image" src="https://user-images.githubusercontent.com/73763010/195076321-93a322e4-6474-4915-b852-785e3877ed79.png">


