### PR TITLE
EIP1-0000 - dependency bump to fix owasp issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.owasp.dependencycheck.reporting.ReportGenerator.Format.HTML
 import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 
 plugins {
-    id("org.springframework.boot") version "2.7.5"
+    id("org.springframework.boot") version "2.7.7"
     id("io.spring.dependency-management") version "1.1.0"
     kotlin("jvm") version "1.7.20"
     kotlin("kapt") version "1.7.20"
@@ -15,7 +15,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
     id("org.jlleitschuh.gradle.ktlint-idea") version "10.3.0"
     id("org.openapi.generator") version "6.2.0"
-    id("org.owasp.dependencycheck") version "7.2.0"
+    id("org.owasp.dependencycheck") version "7.4.3"
 }
 
 group = "uk.gov.dluhc"

--- a/owasp.suppressions.xml
+++ b/owasp.suppressions.xml
@@ -23,14 +23,15 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
-
     <suppress until="2023-09-07Z">
         <notes>
-            <![CDATA[ file name: aws-mysql-jdbc-1.1.1.jar]]>
-            Dependency Checker reports a false positive.
-            False Positive report filed: https://github.com/jeremylong/DependencyCheck/issues/5027
+            <![CDATA[file name: snakeyaml-1.33.jar]]>
+            This vulnerability is on Snakeyaml's Constructor class, where the advice is to use Snakeyaml's SafeConstructor class instead.
+            Spring Boot already uses Snakeyaml's SafeConstructor class, and the content of the parsed yaml (application.yml)
+            is considered trusted.
+            https://github.com/spring-projects/spring-boot/issues/33457
         </notes>
-        <packageUrl regex="true">^pkg:maven/software\.aws\.rds/aws\-mysql\-jdbc@.*$</packageUrl>
-        <cpe>cpe:/a:mysql:mysql</cpe>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
     </suppress>
 </suppressions>


### PR DESCRIPTION
This PR bumps the Spring Boot version to fix a couple of recent owasp dependency check issues; plus also bumps the dependency check plugin itself to the latest version which fixes the false positive that we reported that we had to have a suppression for.
It also adds a new suppression rule for a snakeyml issue that the Spring team have said is not an issue for Spring Boot projects. 

I have deliberately not bumped other dependencies as changing too many dependencies this close to go live feels risky. This is just about fixing all the OWASP dependency issues so that we have a clean slate in this respect for go live.