### PR TITLE
EIP1-0000 - Replaced guava with caffeine cache manager

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,6 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
     implementation("org.mapstruct:mapstruct:1.5.3.Final")
-    implementation("com.google.guava:guava:31.1-jre")
     kapt("org.mapstruct:mapstruct-processor:1.5.3.Final")
 
     // api
@@ -88,6 +87,10 @@ dependencies {
 
     // AWS signer using SDK V2 library is available at https://mvnrepository.com/artifact/io.github.acm19/aws-request-signing-apache-interceptor/2.1.1
     implementation("io.github.acm19:aws-request-signing-apache-interceptor:2.1.1")
+
+    // caching
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine")
 
     // tests
     testImplementation("software.amazon.awssdk:sqs") // required to send messages to a queue, which we only need to do in test at the moment

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/CachingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/CachingConfiguration.kt
@@ -1,13 +1,10 @@
 package uk.gov.dluhc.registercheckerapi.config
 
-import com.google.common.cache.CacheBuilder
+import com.github.benmanes.caffeine.cache.Caffeine
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
-import org.springframework.cache.annotation.CachingConfigurerSupport
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.concurrent.ConcurrentMapCache
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Duration
@@ -16,21 +13,16 @@ const val ERO_CERTIFICATE_MAPPING_CACHE = "eroCertificateMappings"
 
 @Configuration
 @EnableCaching
-class CachingConfiguration : CachingConfigurerSupport() {
+class CachingConfiguration {
     @Value("\${caching.time-to-live}")
     private lateinit var timeToLive: Duration
 
     @Bean
-    @Override
-    override fun cacheManager(): CacheManager {
-        val cacheManager = object : ConcurrentMapCacheManager() {
-            override fun createConcurrentMapCache(name: String): Cache {
-                val map = CacheBuilder.newBuilder().expireAfterWrite(timeToLive).build<Any, Any>().asMap()
-                return ConcurrentMapCache(name, map, true)
+    fun cacheManager(): CacheManager {
+        return CaffeineCacheManager()
+            .apply {
+                setCaffeine(Caffeine.newBuilder().expireAfterWrite(timeToLive))
+                setCacheNames(listOf(ERO_CERTIFICATE_MAPPING_CACHE))
             }
-        }
-
-        cacheManager.setCacheNames(listOf(ERO_CERTIFICATE_MAPPING_CACHE))
-        return cacheManager
     }
 }


### PR DESCRIPTION
This PR replaces `guava` as our cache backing with `caffeine` cache manager. There are 2 reasons for this:

1. `caffeine` is the Spring Boot recommended cache manager, and we have already adopted it in `ero-management-api`
2. `guava` is [triggering a vulnerability](https://valtechhub.slack.com/archives/C03QP1N12P6/p1678584966859879) in our regular OWASP Dependency Scans 

This PR removes the vulnerability and makes our cache configuration consistent with `ero-management-api`