### PR TITLE
EIP1-5155 - Updated MessageQueue so that it works with the correlationId aspect

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/MessageQueue.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/MessageQueue.kt
@@ -1,11 +1,23 @@
 package uk.gov.dluhc.registercheckerapi.messaging
 
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate
+import org.springframework.messaging.Message
+import org.springframework.messaging.core.MessagePostProcessor
 
 class MessageQueue<T : Any>(
     private val queueName: String,
     private val queueMessagingTemplate: QueueMessagingTemplate
 ) {
-    fun submit(message: T) =
-        queueMessagingTemplate.convertAndSend(queueName, message)
+    fun submit(payload: T) =
+        queueMessagingTemplate.send(queueName, queueMessagingTemplate.convertToMessage(payload))
+
+    /**
+     * Extension function on [QueueMessagingTemplate] to allow invocation of it's protected `doConvert` method to
+     * get convert the payload into a [Message] with all the default headers etc.
+     */
+    private fun QueueMessagingTemplate.convertToMessage(payload: T): Message<T> =
+        javaClass.getDeclaredMethod("doConvert", Any::class.java, Map::class.java, MessagePostProcessor::class.java).let {
+            it.isAccessible = true
+            it.invoke(this, payload, null, null) as Message<T>
+        }
 }


### PR DESCRIPTION
This PR updates MessageQueue so that it works with the new correlationId aspect. This is the same change that we had to do in `print-api` (the "blue print" for the correlation ID logging stuff)

(Our `MessageQueue` and `MessageListener` interfaces would be ideal candidates for a shared artefact 👍 )