### PR TITLE
NO-JIRA: Fixes failing intermittent unit test

### DIFF
--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapperTest.kt
@@ -95,7 +95,8 @@ internal class RegisterCheckResultMapperTest {
                 createdAt = createdAt,
                 registerCheckMatchCount = 0,
                 applicationCreatedAt = null,
-                registerCheckMatches = null
+                registerCheckMatches = null,
+                historicalSearchEarliestDate = null,
             )
 
             val expectedMatchSentAt = createdAt.toInstant()
@@ -108,7 +109,8 @@ internal class RegisterCheckResultMapperTest {
                 matchResultSentAt = expectedMatchSentAt,
                 matchCount = apiRequest.registerCheckMatchCount,
                 registerCheckStatus = null,
-                registerCheckMatches = null
+                registerCheckMatches = null,
+                historicalSearchEarliestDate = null,
             )
 
             // When


### PR DESCRIPTION
`historicalSearchEarliestDate` is an optional field which was set by the builders in tests, setting it to null is required so that this unit test `should map api to dto when optional fields are null` works 